### PR TITLE
fix numpy 2.x deprecation warnings and syntax warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
+venv/
 build/
 develop-eggs/
 dist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.9.3
-pandas==0.16.1
-scikit-learn==0.16.1
-scipy==0.16.0
-seaborn==0.5.1
-statsmodels==0.5.0
+numpy
+pandas
+scikit-learn
+scipy
+seaborn
+statsmodels

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@
 import os
 from os import path as op
 
-import setuptools  # noqa; we are using a setuptools namespace
-from numpy.distutils.core import setup
+from setuptools import setup
 
 # get the version 
 version = None

--- a/src/FIRDeconvolution.py
+++ b/src/FIRDeconvolution.py
@@ -100,12 +100,12 @@ class FIRDeconvolution(object):
 
         # if no covariates, we make a new covariate dictionary specifying only ones.
         # we will loop over these covariates instead of the event list themselves to create design matrices
-        if covariates == None:
+        if covariates is None:
             self.covariates = dict(zip(self.event_names, [np.ones(len(ev)) for ev in events]))
         else:
             self.covariates = covariates
 
-        if durations == None:
+        if durations is None:
             self.durations = dict(zip(self.event_names, [np.ones(len(ev))/deconvolution_frequency for ev in events]))
         else:
             self.durations = durations
@@ -222,10 +222,10 @@ class FIRDeconvolution(object):
             :returns: instance variables 'betas' (nr_betas x nr_signals) and 'residuals' (nr_signals x nr_samples) are created.
         """
 
-        if method is 'lstsq':
-            self.betas, residuals_sum, rank, s = LA.lstsq(self.design_matrix.T, self.resampled_signal.T)
+        if method == 'lstsq':
+            self.betas, residuals_sum, rank, s = LA.lstsq(self.design_matrix.T, self.resampled_signal.T, rcond=None)
             self.residuals = self.resampled_signal - self.predict_from_design_matrix(self.design_matrix)
-        elif method is 'sm_ols':
+        elif method == 'sm_ols':
             import statsmodels.api as sm
 
             assert self.resampled_signal.shape[0] == 1, \
@@ -327,7 +327,7 @@ class FIRDeconvolution(object):
         for x in range(bootstrap_data.shape[-1]): # loop over bootstrapsamples
             bootstrap_data[:,x] = (self.residuals.T[np.random.permutation(self.resampled_signal_size)] + explained_signal).squeeze()
 
-        self.bootstrap_betas, bs_residuals, rank, s = LA.lstsq(self.design_matrix.T, bootstrap_data)
+        self.bootstrap_betas, bs_residuals, rank, s = LA.lstsq(self.design_matrix.T, bootstrap_data, rcond=None)
 
         self.bootstrap_betas_per_event_type = np.zeros((len(self.covariates), self.deconvolution_interval_size, nr_repetitions))
 

--- a/test/test.py
+++ b/test/test.py
@@ -131,7 +131,7 @@ fd.calculate_rsq()
 
 f = pl.figure(figsize = (10,8))
 s = f.add_subplot(311)
-s.set_title('FIR responses, Rsq is %1.3f'%fd.rsq)
+s.set_title('FIR responses, Rsq is %1.3f' % float(np.squeeze(fd.rsq)))
 for dec in fd.betas_per_event_type.squeeze():
     pl.plot(fd.deconvolution_interval_timepoints, dec)
 # fd.covariates, being a dictionary, cannot be assumed to maintain the event order. 
@@ -186,7 +186,7 @@ fd.calculate_rsq()
 
 f = pl.figure(figsize = (10,8))
 s = f.add_subplot(311)
-s.set_title('FIR responses, Rsq is %1.3f'%fd.rsq)
+s.set_title('FIR responses, Rsq is %1.3f' % float(np.squeeze(fd.rsq)))
 for dec in fd.betas_per_event_type.squeeze():
     pl.plot(fd.deconvolution_interval_timepoints, dec)
 # fd.covariates, being a dictionary, cannot be assumed to maintain the event order. 


### PR DESCRIPTION
## Summary
- Replace `is` / `== None` comparisons with `==` / `is None` (was `SyntaxWarning`).
- Pass explicit `rcond=None` to `numpy.linalg.lstsq` in `regress` and `bootstrap_on_residuals` (silences `FutureWarning`).
- Switch `setup.py` from the removed `numpy.distutils.core` to plain `setuptools` so `pip install -e .` works on modern NumPy.
- Update `test/test.py` to convert `fd.rsq` to a scalar before formatting — NumPy 2.x no longer implicitly converts 1-element arrays.
- Unpin `requirements.txt` (the 2015 pins won't build on Python 3.11).
- Add `.venv/` and `venv/` to `.gitignore`.

## Test plan
- [x] `python -W error::DeprecationWarning -W error::FutureWarning -W error::SyntaxWarning -W error::RuntimeWarning test/test.py` — clean exit.
- [x] Exercise `lstsq`, `sm_ols`, `ridge_regress`, and `bootstrap_on_residuals` under the same strict warnings — clean.
- [x] `pip install -e .` succeeds under Python 3.11 with NumPy 2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012koxbxL1DXZ1y8Gn2D2oLR

---
_Generated by [Claude Code](https://claude.ai/code/session_012koxbxL1DXZ1y8Gn2D2oLR)_